### PR TITLE
Move _select encoding and decoding to threads.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,13 +10,8 @@ class FlutterContactsExample extends StatefulWidget {
 
 class _FlutterContactsExampleState extends State<FlutterContactsExample> {
   List<Contact>? _contacts;
+  bool _notStarted = true;
   bool _permissionDenied = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _fetchContacts();
-  }
 
   Future _fetchContacts() async {
     if (!await FlutterContacts.requestPermission(readonly: true)) {
@@ -34,6 +29,17 @@ class _FlutterContactsExampleState extends State<FlutterContactsExample> {
           body: _body()));
 
   Widget _body() {
+    if (_notStarted) {
+      return Center(
+        child: ElevatedButton(
+          onPressed: () {
+            setState(() => _notStarted = false);
+            _fetchContacts();
+          },
+          child: Text('Start'),
+        ),
+      );
+    }
     if (_permissionDenied) return Center(child: Text('Permission denied'));
     if (_contacts == null) return Center(child: CircularProgressIndicator());
     return ListView.builder(


### PR DESCRIPTION
This includes 3 separate changes:
1. In FlutterContactsPlugin.kt, encode the _select results in the same thread in which fetching is done, instead of on the main thread.
2. In flutter_contacts.dart, decode on a separate dart isolate.
3. In example/main.dart, start fetching the contacts after the user presses the button.

There is still non-responsiveness. I think it's shorter.

The change in FlutterContactsPlugin.kt is reasonable - it just follows the implementation of MethodCallHandler, which is pretty small.

The change in flutter_contacts.dart is pretty ugly. I'm really not sure it's worth it.

The change in example/main.dart was useful because it allowed me to start profiling and then press the button.

I send this mostly as reference. If I were the maintainer, I would see how much the change in FlutterContactsPlugin.kt shortens the non-responsive time, and decide if it's worth the (not too big) added complexity. I would not merge the change in flutter_contacts.dart.

I hope this helps,
Noam