### PR TITLE
Fix bug

### DIFF
--- a/lib/properties/address.dart
+++ b/lib/properties/address.dart
@@ -80,8 +80,7 @@ class Address {
 
   factory Address.fromJson(Map<String, dynamic> json) => Address(
         (json['address'] as String?) ?? '',
-        label: _stringToAddressLabel[json['label'] as String? ?? ''] ??
-            '' as AddressLabel,
+        label: _stringToAddressLabel[json['label'] as String? ?? ''] ?? AddressLabel.home,
         customLabel: (json['customLabel'] as String?) ?? '',
         street: (json['street'] as String?) ?? '',
         pobox: (json['pobox'] as String?) ?? '',


### PR DESCRIPTION
This will fix this error
```
Exception: type '_OneByteString' is not a subtype of type 'AddressLabel' in type cast 
       at new Address.fromJson(address.dart:84)
       at new Contact.fromJson.<fn>(contact.dart:175)
       at SetMixin.toList(dart:collection)
       at new Contact.fromJson(contact.dart:176)
       at FlutterContacts._select.<fn>(flutter_contacts.dart:329)
       at SetMixin.toList(dart:collection)
       at FlutterContacts._select(flutter_contacts.dart:330)
```