### PR TITLE
Add the withProperties pram in getContacts

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class _FlutterContactsExampleState extends State<FlutterContactsExample> {
     if (!await FlutterContacts.requestPermission(readonly: true)) {
       setState(() => _permissionDenied = true);
     } else {
-      final contacts = await FlutterContacts.getContacts();
+      final contacts = await FlutterContacts.getContacts(withProperties: true);
       setState(() => _contacts = contacts);
     }
   }


### PR DESCRIPTION
The example uses the contact's emails and phones properties, which would not be populated unless the withProperties parameters is set to true