### PR TITLE
Fix normalized number by removing ( and -) in phone

### DIFF
--- a/android/src/main/kotlin/co/quis/flutter_contacts/FlutterContacts.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/FlutterContacts.kt
@@ -279,9 +279,10 @@ class FlutterContacts {
                             val label: String = getPhoneLabel(cursor)
                             val customLabel: String =
                                 if (label == "custom") getPhoneCustomLabel(cursor) else ""
+                            val normalizedNumber: String = getString(Phone.NUMBER).replace("(","").replace(")","").replace("-","")
                             val phone = PPhone(
                                 getString(Phone.NUMBER),
-                                getString(Phone.NORMALIZED_NUMBER),
+                                normalizedNumber,
                                 label,
                                 customLabel,
                                 getInt(Phone.IS_PRIMARY) == 1


### PR DESCRIPTION
Normalized number returns blank when the number contains brackets. So got the normalized number by removing the brackes and hyphens in the phone