### PR TITLE
Revert addition of namespace to avoid build fails on old AGPs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,8 +30,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
     
-    if (!project.hasProperty("android.buildCacheDir")) {
-        namespace "com.something.plugin"
+    if (!project.hasProperty("namespace")) {
+        namespace 'co.quis.flutter_contacts'
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,8 +29,10 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
-
-    namespace 'co.quis.flutter_contacts'
+    
+    if (!project.hasProperty("android.buildCacheDir")) {
+        namespace "com.something.plugin"
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="co.quis.flutter_contacts">
 </manifest>


### PR DESCRIPTION
Reverting namespace addition to release a fix for those who use old AGP versions.

Fix for Issue #127 