### PR TITLE
FIX: Incompatible java target with newest versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,12 +6,11 @@ buildscript {
     ext.kotlin_coroutines_version = '1.6.4'
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -19,7 +18,6 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }
@@ -28,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     if (!project.hasProperty("namespace")) {
         namespace 'co.quis.flutter_contacts'
@@ -41,10 +39,13 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
+        targetSdkVersion 34
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,11 @@ android {
         namespace 'co.quis.flutter_contacts'
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -41,7 +46,6 @@ android {
     }
 
     defaultConfig {
-        targetSdkVersion 34
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,10 @@ android {
         namespace 'co.quis.flutter_contacts'
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Hello, current PR resolves #169. While trying to run application on newest versions you may encounter:

`Execution failed for task ':flutter_contacts:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain`
  
and because of that, you cannot compile application since package is targeting version lower than expected. Since we are targeting SDK 34, we should as well support Java 1.8



Fixes #169 


PR includes as well support for SDK 34, since it supports now compileSDK