### PR TITLE
Setting the correct type for notes onDelete() ans adding onUpdate()

### DIFF
--- a/example_full/lib/pages/edit_contact_page.dart
+++ b/example_full/lib/pages/edit_contact_page.dart
@@ -331,8 +331,8 @@ class _EditContactPageState extends State<EditContactPage>
         () => _contact.notes = _contact.notes + [Note('')],
         (int i, dynamic w) => NoteForm(
           w,
-          onUpdate: null,
-          onDelete: () => setState(() => _contact.groups.removeAt(i)),
+          onUpdate: (note) = _contacts.notes[i] = note,
+          onDelete: () => setState(() => _contact.notes.removeAt(i)),
           key: UniqueKey(),
         ),
         () => _contact.notes = [],


### PR DESCRIPTION
The _noteCard() in example_full\lib\pages\edit_contact_page.dart file erroneously points to _contact.groups for onDelete(). This throws an null/empty error when one adds a note and tries to delete it (as is). This fix ensures the notes property is the one targeted. Adding onUpdate() that was initially null