### PR TITLE
Update Android SDK version to 36 and fix breaking changes 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 36
 
     namespace 'co.quis.flutter_contacts'
 

--- a/android/src/main/kotlin/co/quis/flutter_contacts/FlutterContactsPlugin.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/FlutterContactsPlugin.kt
@@ -207,7 +207,7 @@ class FlutterContactsPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
                     val args = call.arguments as List<Any>
                     val contact = args[0] as Map<String, Any>
                     val insertedContact: Map<String, Any?>? =
-                        FlutterContacts.insert(resolver!!, contact)
+                        FlutterContacts.insert(resolver!!, context!!, contact)
                     coroutineScope.launch(Dispatchers.Main) {
                         if (insertedContact != null) {
                             result.success(insertedContact)


### PR DESCRIPTION
- Bumped compileSdk version from 34 to 36 in build.gradle.
- Modified FlutterContacts.kt to include context in the insert method for better account handling.
- Added logging for contact insertion and account retrieval to improve debugging.
- Implemented a method to get the system's default cloud account for new contacts, ensuring compatibility with cloud account scenarios.


fixes https://github.com/QuisApp/flutter_contacts/issues/205