### PR TITLE
Fix Insert Operation and for devices below android 13 insert operation failing 

### DIFF
--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/AccountUtils.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/AccountUtils.kt
@@ -335,7 +335,13 @@ object AccountUtils {
         }
 
         @Suppress("DEPRECATION")
-        val defaultAccount = Settings.getDefaultAccount(contentResolver)
+        val defaultAccount = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Settings.getDefaultAccount(contentResolver)
+        } else {
+            // returning null is the correct behavior, letting
+            // the contacts provider pick the default itself.
+            null
+        }
         return if (defaultAccount != null &&
             defaultAccount.name.isNotEmpty() &&
             defaultAccount.type.isNotEmpty()

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/ContactBuilder.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/ContactBuilder.kt
@@ -58,14 +58,12 @@ object ContactBuilder {
             build: (T, Boolean) -> ContentProviderOperation,
         ) = items.forEach { addOp(build(it, shouldYield())) }
 
-        addOp(
+         addOp(
             ContentProviderOperation
                 .newInsert(RawContacts.CONTENT_URI)
                 .apply {
-                    account?.let {
-                        withValue(RawContacts.ACCOUNT_TYPE, it.type)
-                        withValue(RawContacts.ACCOUNT_NAME, it.name)
-                    }
+                    withValue(RawContacts.ACCOUNT_TYPE, account?.type)
+                    withValue(RawContacts.ACCOUNT_NAME, account?.name)
                 }.build(),
         )
 


### PR DESCRIPTION
fix: resolve PlatformException when creating contacts with null account
Problem
Creating a new contact crashed with:
PlatformException(flutter_contacts_error, Failed to handle create: 
Attempt to invoke virtual method 'java.util.Set 
android.content.ContentValues.keySet()' on a null object reference)
This occurred because when account is null, the ContentProviderOperation insert was built without any values, resulting in a null ContentValues object that the contacts provider couldn't process.
Root cause: devices below Android 13 (API 33) have no public API to retrieve the default account, so getDefaultAccount() correctly returns null — but the insert operation wasn't handling that case gracefully.
Fix
Guard the withValue calls inside an account?.let block so that when no account is available, the RawContacts row is inserted without explicit account fields, allowing the contacts provider to assign its own default account.
Affected versions

Android < 13 (API < 33): no default account API exists — null is expected and now handled
Android 13–15 (API 33–35): uses Settings.getDefaultAccount()
Android 16+ (API 36+): uses RawContacts.DefaultAccount.getDefaultAccountForNewContacts()
