### PR TITLE
Fix Android 12 and below account resolution and relax Dart/Flutter constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-beta.5
+
+- Relax Dart/Flutter version requirements
+- Fix for older Android versions without Settings.getDefaultAccount()
+
 ## 2.0.0-beta.4
 
 - Migrate to Swift Package Manager

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/AccountUtils.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/AccountUtils.kt
@@ -334,8 +334,15 @@ object AccountUtils {
             }
         }
 
+        // Settings.getDefaultAccount() exists only from Android 13 (API 33) onward.
+        // On older devices, returning null lets the contacts provider pick the default account.
         @Suppress("DEPRECATION")
-        val defaultAccount = Settings.getDefaultAccount(contentResolver)
+        val defaultAccount =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                Settings.getDefaultAccount(contentResolver)
+            } else {
+                null
+            }
         return if (defaultAccount != null &&
             defaultAccount.name.isNotEmpty() &&
             defaultAccount.type.isNotEmpty()

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,5 +8,5 @@ import Foundation
 import flutter_contacts
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-    FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
+  FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-beta.3"
+    version: "2.0.0-beta.5"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -209,4 +209,4 @@ packages:
     version: "15.0.2"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  flutter: ">=3.32.0"

--- a/lib/api/crud_api.dart
+++ b/lib/api/crud_api.dart
@@ -57,7 +57,7 @@ class CrudApi {
         'properties': props.toJson(),
         if (filter != null) 'filter': filter.toJson(),
         if (account != null) 'account': account.toJson(),
-        if (limit != null) 'limit': limit,
+        'limit': ?limit,
       }),
     );
     return JsonHelpers.decodeList(result, Contact.fromJson);

--- a/lib/api/ringtones_api.dart
+++ b/lib/api/ringtones_api.dart
@@ -63,7 +63,7 @@ class RingtonesApi {
   Future<String?> pick(RingtoneType type, {String? existingUri}) =>
       _invoke<String>('ringtones.pick', {
         'type': type.name,
-        if (existingUri != null) 'existingUri': existingUri,
+        'existingUri': ?existingUri,
       });
 
   /// Gets the default ringtone URI for the given type.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 2.0.0-beta.4
 repository: https://github.com/QuisApp/flutter_contacts
 
 environment:
-  sdk: ^3.11.0
-  flutter: ">=3.41.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts
 description: "Fast, complete contact management for Android, iOS & macOS — all fields, groups, accounts, vCards, native dialogs, listeners, SIM contacts, and number blocking."
-version: 2.0.0-beta.4
+version: 2.0.0-beta.5
 repository: https://github.com/QuisApp/flutter_contacts
 
 environment:


### PR DESCRIPTION
# Fix Android 12 and below account resolution and relax Dart/Flutter constraints

## Summary
- Fix crash on Android 12 and below when resolving the default account by guarding use of Settings.getDefaultAccount() to API 33+.
- Relax Dart and Flutter version constraints so the package works with older SDKs.
- Bump package version to 2.0.0-beta.5 and apply formatting/lint fixes.

## Key Changes
- Android: Call Settings.getDefaultAccount() only when Build.VERSION.SDK_INT >= TIRAMISU (API 33); on older versions use null so the contacts provider chooses the default account.
- pubspec.yaml: Dart constraint changed from ^3.11.0 to ">=3.8.0 <4.0.0"; Flutter from ">=3.41.0" to ">=3.32.0".
- Version set to 2.0.0-beta.5; CHANGELOG updated for this release.
- Map literals in crud_api.dart and ringtones_api.dart updated (limit and existingUri) to satisfy lints.
- Formatting applied (e.g. example macOS GeneratedPluginRegistrant.swift); example pubspec.lock updated.

## Technical Notes
- Settings.getDefaultAccount() was added in Android 13 (API 33). Calling it on older devices caused the failure; returning null on pre-TIRAMISU lets the platform contacts provider apply its default account behavior.

## Testing
N/A