### PR TITLE
Fix Android build failure from hardcoded Flutter SDK path (#223)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ migrate_working_dir/
 
 # Flutter metadata (auto-generated)
 .metadata
+
+# oh-my-claudecode
+.omc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fix Android build failure from hardcoded Flutter SDK path (#223)
+
 ## 2.0.0
 
 - Stable 2.0 release. Includes all changes from 2.0.0-beta.1 through 2.0.0-beta.5.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,22 @@ allprojects {
     }
 }
 
-def flutterRoot = System.getenv('FLUTTER_ROOT') ?: '/opt/homebrew/Caskroom/flutter/3.32.4/flutter'
+// Resolve Flutter SDK path from local.properties (standard Flutter approach)
+def localProperties = new Properties()
+def localPropertiesFile = new File(rootProject.projectDir, 'local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader -> localProperties.load(reader) }
+}
+
+def flutterRoot = localProperties.getProperty('flutter.sdk')
+    ?: System.getenv('FLUTTER_ROOT')
+
+if (flutterRoot == null) {
+    throw new GradleException(
+        "Flutter SDK not found. Define flutter.sdk in local.properties or set FLUTTER_ROOT."
+    )
+}
+
 def engineVersion = new File(flutterRoot, 'bin/cache/engine.stamp').text.trim()
 
 apply plugin: 'com.android.library'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ def flutterRoot = localProperties.getProperty('flutter.sdk')
 
 if (flutterRoot == null) {
     throw new GradleException(
-        "Flutter SDK not found. Define flutter.sdk in local.properties or set FLUTTER_ROOT."
+        'Flutter SDK not found. Define flutter.sdk in local.properties or set FLUTTER_ROOT.'
     )
 }
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,5 +8,5 @@ import Foundation
 import flutter_contacts
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
+    FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-beta.5"
+    version: "2.0.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -110,10 +110,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts
 description: "Fast, complete contact management for Android, iOS & macOS — all fields, groups, accounts, vCards, native dialogs, listeners, SIM contacts, and number blocking."
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/QuisApp/flutter_contacts
 
 environment:


### PR DESCRIPTION
## Summary
- Fix Android build.gradle to resolve Flutter SDK path from local.properties instead of hardcoded path
- Bump version to 2.0.1
- Add .omc/ to .gitignore

## Test plan
- [x] Tested Android build
- [x] Tested iOS build
- [x] Tested macOS build

🤖 Generated with [Claude Code](https://claude.com/claude-code)