### PR TITLE
Add Claude Code workflow skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,44 @@
+# Claude Skills for flutter_contacts
+
+Project-specific skills for the development workflow. Invoke with `/<skill-name>` in Claude Code.
+
+## Workflow
+
+A typical release workflow looks like:
+
+```
+/branch              # create tmp-fixes branch (or /branch my-feature)
+# ... make changes ...
+/check               # run format, test, analyze
+/run                 # run on physical devices
+/commit              # stage and commit changes
+/bump patch          # bump version
+/commit              # commit version bump
+/ship                # push, squash-merge to main, tag, cleanup
+/publish             # publish to pub.dev
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/branch [description]` | Create a working branch (derives name from description, defaults to `tmp-fixes`) |
+| `/check [format\|test\|analyze]` | Run code quality checks (all if omitted) |
+| `/run [ios\|android\|macos\|all]` | Run example app on physical devices |
+| `/commit` | Stage and commit with auto-generated message |
+| `/bump [patch\|minor\|major]` | Bump version in pubspec.yaml + CHANGELOG (defaults to patch) |
+| `/ship` | Push, squash-merge to main, tag, cleanup branch |
+| `/publish [dry-run]` | Publish to pub.dev (dry-run first) |
+
+## Setup
+
+The `/run` skill requires a `.claude/.env` file with device IDs:
+
+```
+ANDROID_DEVICE_ID=<your-android-device-id>
+IOS_DEVICE_ID=<your-ios-device-id>
+```
+
+macOS runs with `-d macos` and needs no device ID.
+
+To find your device IDs, run `flutter devices`.

--- a/.claude/skills/branch/SKILL.md
+++ b/.claude/skills/branch/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: branch
+description: Create a temporary working branch from main. Use when starting a new task or fix.
+argument-hint: [description of upcoming work]
+---
+
+Create a temporary working branch for a new task.
+
+## Steps
+
+1. Run `git checkout main && git pull` to ensure main is up to date.
+2. Determine the branch name:
+   - If `$ARGUMENTS` describes the work, derive a short kebab-case branch name from it (e.g., "fix android build" → `fix-android-build`).
+   - If `$ARGUMENTS` is empty, default to `tmp-fixes`.
+3. Run `git checkout -b <branch-name>`.
+4. Confirm the branch was created and you're on it.

--- a/.claude/skills/bump/SKILL.md
+++ b/.claude/skills/bump/SKILL.md
@@ -18,4 +18,6 @@ Bump the package version and update the changelog.
 5. Update `version:` in `pubspec.yaml`.
 6. Add a new section at the top of `CHANGELOG.md` with the new version number.
 7. Generate changelog entries from recent commits since the last tag.
-8. Do NOT commit — let the user review and commit separately.
+8. Regenerate API docs: `scripts/doc.sh`
+9. Open the docs: `open doc/api/index.html`
+10. Do NOT commit — let the user review and commit separately.

--- a/.claude/skills/bump/SKILL.md
+++ b/.claude/skills/bump/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: bump
+description: Bump the package version in pubspec.yaml and add a CHANGELOG entry. Defaults to patch bump.
+argument-hint: [patch|minor|major] (defaults to patch)
+---
+
+Bump the package version and update the changelog.
+
+## Steps
+
+1. Read the current version from `pubspec.yaml`.
+2. Parse the version as `major.minor.patch`.
+3. Determine bump type from `$ARGUMENTS` (patch, minor, or major). Default to **patch** if not specified.
+4. Compute the new version:
+   - **patch**: increment patch (e.g., 2.0.1 → 2.0.2)
+   - **minor**: increment minor, reset patch (e.g., 2.0.1 → 2.1.0)
+   - **major**: increment major, reset minor and patch (e.g., 2.0.1 → 3.0.0)
+5. Update `version:` in `pubspec.yaml`.
+6. Add a new section at the top of `CHANGELOG.md` with the new version number.
+7. Generate changelog entries from recent commits since the last tag.
+8. Do NOT commit — let the user review and commit separately.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: check
+description: Run code quality checks — format, test, and analyze. Use when asked to check, lint, format, or test the codebase.
+argument-hint: [format|test|analyze] (runs all if omitted)
+---
+
+Run code quality checks on the project.
+
+## Steps
+
+If `$ARGUMENTS` specifies a specific check (format, test, or analyze), run only that one. Otherwise run all three in order:
+
+1. **Format**: `scripts/format`
+2. **Test**: `scripts/test`
+3. **Analyze**: `flutter analyze`
+
+Report results after each step. If any step fails, stop and report the failure.

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -10,8 +10,8 @@ Run code quality checks on the project.
 
 If `$ARGUMENTS` specifies a specific check (format, test, or analyze), run only that one. Otherwise run all three in order:
 
-1. **Format**: `scripts/format`
-2. **Test**: `scripts/test`
+1. **Format**: `scripts/format.sh`
+2. **Test**: `scripts/test.sh`
 3. **Analyze**: `flutter analyze`
 
 Report results after each step. If any step fails, stop and report the failure.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: commit
+description: Stage and commit changes with an auto-generated message. Use when asked to commit current changes.
+---
+
+Stage and commit the current changes.
+
+## Steps
+
+1. Run `git status` and `git diff` to understand what changed.
+2. Stage the relevant files (prefer specific files over `git add -A`). Never stage `.env` files or secrets.
+3. Generate a concise commit message from the diff (1-2 sentences, focus on the "why").
+4. Commit with the co-author trailer:
+   ```
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   ```
+5. Show the result with `git log --oneline -1`.

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: publish
+description: Publish the package to pub.dev. Runs dry-run first, then publishes on confirmation.
+argument-hint: [dry-run] (runs dry-run only if specified)
+---
+
+Publish the package to pub.dev.
+
+## Steps
+
+1. Run `flutter pub publish --dry-run` and show the output.
+2. If `$ARGUMENTS` is "dry-run", stop here.
+3. Otherwise, ask the user to confirm before proceeding.
+4. On confirmation, run `flutter pub publish --force` (non-interactive).
+5. Report success or failure.

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: run
+description: Run the example app on physical devices. Requires .claude/.env with device IDs. Use when asked to run on devices.
+argument-hint: [ios|android|macos|all] (defaults to all)
+---
+
+Run the example app on physical devices. Device IDs are configured in `.claude/.env`.
+
+## Environment
+
+Load device IDs from `.claude/.env`:
+- `ANDROID_DEVICE_ID` — Android device
+- `IOS_DEVICE_ID` — iOS device
+- macOS needs no device ID
+
+The shell aliases `i7` (iOS), `a` (Android), and `m` (macOS) may be available but don't work in non-interactive shells. Use `flutter run -d <device-id>` directly instead.
+
+## Steps
+
+1. Read `.claude/.env` to get device IDs.
+2. Determine which devices to target from `$ARGUMENTS` (ios, android, macos, or all). Default is all.
+3. `cd example` before running.
+4. Run each device in the background:
+   - **Android**: `flutter run -d $ANDROID_DEVICE_ID`
+   - **iOS**: `flutter run -d $IOS_DEVICE_ID`
+   - **macOS**: `flutter run -d macos`
+5. Report build/launch results.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -18,6 +18,8 @@ Ship the current branch to main.
 4. Squash-merge the PR: `gh pr merge --squash --delete-branch`.
 5. Checkout main and pull: `git checkout main && git pull`.
 6. Delete the local branch if it still exists: `git branch -d <branch>`.
-7. Read the version from `pubspec.yaml` and prefix with `v` for the tag.
-8. Create and push the tag: `git tag -a <tag> -m "<tag>" && git push origin <tag>`.
-9. Confirm completion with a summary.
+7. **Tag** (auto-detect):
+   - Read the version from `pubspec.yaml` and prefix with `v` (e.g. `v2.0.1`).
+   - If that tag already exists (`git tag -l <tag>`), skip tagging.
+   - Otherwise, create and push the tag: `git tag -a <tag> -m "<tag>" && git push origin <tag>`.
+8. Confirm completion with a summary (mention whether a tag was created or skipped).

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: ship
+description: Ship the current branch — push, squash-merge to main via PR, tag, and clean up. Use when ready to merge and release.
+---
+
+Ship the current branch to main.
+
+## Prerequisites
+
+- Must NOT be on `main` branch already. If on main, abort with a message.
+- Working tree should be clean. If not, warn the user.
+
+## Steps
+
+1. Get the current branch name.
+2. Push the branch to origin: `git push -u origin <branch>`.
+3. Create a PR targeting main using `gh pr create`. Use the squashed commit subjects as the PR body.
+4. Squash-merge the PR: `gh pr merge --squash --delete-branch`.
+5. Checkout main and pull: `git checkout main && git pull`.
+6. Delete the local branch if it still exists: `git branch -d <branch>`.
+7. Read the version from `pubspec.yaml` and prefix with `v` for the tag.
+8. Create and push the tag: `git tag -a <tag> -m "<tag>" && git push origin <tag>`.
+9. Confirm completion with a summary.

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ migrate_working_dir/
 
 # oh-my-claudecode
 .omc/
+
+# Claude Code (device-specific config)
+.claude/.env


### PR DESCRIPTION
## Summary
- Add Claude Code workflow skills for common tasks: check, commit, branch, ship, run, bump, and publish
- Fix script paths in check skill and add doc generation to bump skill
- Improve ship skill tagging to auto-detect and skip existing tags

## Commits
- c93a31d Add Claude Code workflow skills
- 773f48b Fix script paths in check skill and add doc generation to bump skill
- 0c55837 Improve ship skill tagging to skip existing tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)