### PR TITLE
Permissionless native picker and dedupe aggregated phones/emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.0
+
+- `FlutterContacts.native.showPicker()` now returns `Contact?` (with `id` and
+  `displayName` always populated) and accepts a `properties:` set for additional
+  fields. The picker itself remains permissionless on both platforms; on Android,
+  requesting `properties` requires `READ_CONTACTS` and throws otherwise.
+  **Breaking:** replace `await …showPicker()` with `(await …showPicker())?.id` (#232).
+
 ## 2.0.2
 
 - Fix Flutter SDK resolution for FVM and IDE sync compatibility (#227)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   fields. The picker itself remains permissionless on both platforms; on Android,
   requesting `properties` requires `READ_CONTACTS` and throws otherwise.
   **Breaking:** replace `await …showPicker()` with `(await …showPicker())?.id` (#232).
+- Dedupe phone numbers and emails returned by aggregated contacts on Android,
+  keyed on normalized value + label (#229).
 
 ## 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ final status = await FlutterContacts.permissions.request(PermissionType.readWrit
 if (status == PermissionStatus.granted) {
   // Get all contacts (fast - defaults to IDs and display names only)
   List<Contact> contacts = await FlutterContacts.getAll();
-  
+
   // Get a specific contact with all properties
   Contact? contact = await FlutterContacts.get(
     contacts.first.id!,
@@ -84,12 +84,12 @@ if (status == PermissionStatus.granted) {
 
 ### 📐 API Structure
 
-| Category | API | Purpose |
-| --- | --- | --- |
-| **Core CRUD** | `FlutterContacts.get()`, `.getAll()`, `.create()`, `.createAll()`, `.update()`, `.updateAll()`, `.delete()`, `.deleteAll()` | Contact operations |
-| **Feature APIs** | `FlutterContacts.accounts`, `.groups`, `.permissions`, `.vCard`, `.native`, `.config` | Specialized features |
-| **Platform APIs** | `FlutterContacts.sim` (Android), `.profile` (Android/macOS), `.blockedNumbers` (Android), `.ringtones` (Android) | Platform-specific |
-| **Streams** | `FlutterContacts.onDatabaseChange`, `.onContactChange` | Real-time notifications |
+| Category          | API                                                                                                                         | Purpose                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| **Core CRUD**     | `FlutterContacts.get()`, `.getAll()`, `.create()`, `.createAll()`, `.update()`, `.updateAll()`, `.delete()`, `.deleteAll()` | Contact operations      |
+| **Feature APIs**  | `FlutterContacts.accounts`, `.groups`, `.permissions`, `.vCard`, `.native`, `.config`                                       | Specialized features    |
+| **Platform APIs** | `FlutterContacts.sim` (Android), `.profile` (Android/macOS), `.blockedNumbers` (Android), `.ringtones` (Android)            | Platform-specific       |
+| **Streams**       | `FlutterContacts.onDatabaseChange`, `.onContactChange`                                                                      | Real-time notifications |
 
 ### ⚡ Selective Fetching
 
@@ -150,11 +150,11 @@ contacts_service_plus     █████████████░░░░░
 flutter_contacts v1       ███████████████████████░  803   ███████████████████████  1075
 ```
 
-| V2 vs V1            | iOS           | Android        |
-| ------------------- | ------------- | -------------- |
-| **Read speed**      | 1.6–7x faster | 2–5x faster    |
-| **Bulk create**     | 4x faster     | 5x faster      |
-| **Bulk delete**     | 34x faster    | 140x faster    |
+| V2 vs V1        | iOS           | Android     |
+| --------------- | ------------- | ----------- |
+| **Read speed**  | 1.6–7x faster | 2–5x faster |
+| **Bulk create** | 4x faster     | 5x faster   |
+| **Bulk delete** | 34x faster    | 140x faster |
 
 _See the [benchmark repository](https://github.com/QuisApp/flutter_contacts_benchmark) for detailed methodology and feature comparison._
 
@@ -265,14 +265,22 @@ Supports vCard 2.1, 3.0, and 4.0.
 <details>
 <summary><b>🎨 Native Dialogs</b> (Android & iOS)</summary>
 
-No permissions required - uses system UI.
+System UI for picking, viewing, editing, and creating contacts.
 
 ```dart
-String? pickedId = await FlutterContacts.native.showPicker();
+Contact? picked = await FlutterContacts.native.showPicker(
+  properties: {ContactProperty.phone},
+);
 await FlutterContacts.native.showViewer(contactId);
 String? editedId = await FlutterContacts.native.showEditor(contactId);
 String? createdId = await FlutterContacts.native.showCreator(contact: prefill);
 ```
+
+Permissions:
+
+- `showPicker()` and `showCreator()` need no contacts permission on either platform.
+- `showPicker(properties: …)` is permissionless on iOS. On Android it requires `READ_CONTACTS` and throws `PlatformException` if missing.
+- `showViewer()` and `showEditor()` are permissionless on Android. On iOS they require `NSContactsUsageDescription` in `Info.plist` and a granted read permission.
 
 </details>
 
@@ -460,6 +468,7 @@ Phone('555-1234', label: Label(PhoneLabel.custom, customLabel: 'Emergency'))
 <summary><b>iOS & macOS</b></summary>
 
 **Not Available:**
+
 - APIs: `ringtones`, `blockedNumbers`, `sim`, `profile` (iOS), `native` (macOS)
 - Properties: `favorite`, `ringtone`, `sendToVoicemail`, `timestamp`, `identifiers`, `debugData` (all nested in `android` field)
 - Fields: `Phone.isPrimary`, `Phone.normalizedNumber`, `Email.isPrimary`, `Address.poBox`, `Address.neighborhood`, `Organization.jobDescription`, `Organization.symbol`, `Organization.officeLocation`
@@ -477,10 +486,12 @@ Phone('555-1234', label: Label(PhoneLabel.custom, customLabel: 'Emergency'))
 <summary><b>Android</b></summary>
 
 **Not Available:**
+
 - Fields: `Name.previousFamilyName`, `Address.isoCountryCode`, `Address.subAdministrativeArea`, `Address.subLocality`
 - Some iOS-specific labels (auto-converted to custom)
 
 **Special Features:**
+
 - **SIM Contacts:** Read-only, typically name + phone only
 - **Blocked Numbers:** Requires app to be default phone app
 
@@ -492,19 +503,19 @@ Phone('555-1234', label: Label(PhoneLabel.custom, customLabel: 'Emergency'))
 
 If you're using [flutter_contacts v1](https://pub.dev/packages/flutter_contacts/versions/1.1.9+2):
 
-| v1 | v2 |
-| --- | --- |
-| `FlutterContacts.getContacts()` | `FlutterContacts.getAll()` |
-| `FlutterContacts.getContact(id)` | `FlutterContacts.get(id)` |
-| `contact.insert()` | `FlutterContacts.create(contact)` |
-| `FlutterContacts.requestPermission()` | `FlutterContacts.permissions.request(PermissionType.readWrite)` |
-| `FlutterContacts.addListener()` | `FlutterContacts.onDatabaseChange.listen()` |
-| `contact.toVCard()` | `FlutterContacts.vCard.export(contact)` |
-| `PhoneLabel.mobile` | `Label(PhoneLabel.mobile)` |
-| `FlutterContacts.openExternalView(id)` | `FlutterContacts.native.showViewer(id)` |
-| `FlutterContacts.openExternalPick()` | `FlutterContacts.native.showPicker()` |
-| `FlutterContacts.openExternalEdit(id)` | `FlutterContacts.native.showEditor(id)` |
-| `FlutterContacts.openExternalInsert()` | `FlutterContacts.native.showCreator()` |
+| v1                                     | v2                                                              |
+| -------------------------------------- | --------------------------------------------------------------- |
+| `FlutterContacts.getContacts()`        | `FlutterContacts.getAll()`                                      |
+| `FlutterContacts.getContact(id)`       | `FlutterContacts.get(id)`                                       |
+| `contact.insert()`                     | `FlutterContacts.create(contact)`                               |
+| `FlutterContacts.requestPermission()`  | `FlutterContacts.permissions.request(PermissionType.readWrite)` |
+| `FlutterContacts.addListener()`        | `FlutterContacts.onDatabaseChange.listen()`                     |
+| `contact.toVCard()`                    | `FlutterContacts.vCard.export(contact)`                         |
+| `PhoneLabel.mobile`                    | `Label(PhoneLabel.mobile)`                                      |
+| `FlutterContacts.openExternalView(id)` | `FlutterContacts.native.showViewer(id)`                         |
+| `FlutterContacts.openExternalPick()`   | `FlutterContacts.native.showPicker()`                           |
+| `FlutterContacts.openExternalEdit(id)` | `FlutterContacts.native.showEditor(id)`                         |
+| `FlutterContacts.openExternalInsert()` | `FlutterContacts.native.showCreator()`                          |
 
 ---
 

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/PropertyUtils.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/PropertyUtils.kt
@@ -228,7 +228,11 @@ object PropertyUtils {
     private fun dedupeEmails(emails: List<Email>): List<Email> {
         val seen = HashSet<Triple<String, String, String?>>()
         return emails.filter { email ->
-            val normalized = email.address.trim().lowercase().ifEmpty { return@filter true }
+            val normalized =
+                email.address
+                    .trim()
+                    .lowercase()
+                    .ifEmpty { return@filter true }
             seen.add(Triple(normalized, email.label.label, email.label.customLabel))
         }
     }

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/PropertyUtils.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/PropertyUtils.kt
@@ -208,9 +208,30 @@ object PropertyUtils {
         dataId: (T) -> String?,
     ) = items.sortedWith(compareBy({ isPrimary(it) != true }, { dataId(it).orEmpty() }))
 
-    fun sortPhones(phones: List<Phone>) = sortByPrimaryThenId(phones, isPrimary = { it.isPrimary }, dataId = { it.metadata?.dataId })
+    fun sortPhones(phones: List<Phone>) =
+        sortByPrimaryThenId(dedupePhones(phones), isPrimary = { it.isPrimary }, dataId = { it.metadata?.dataId })
 
-    fun sortEmails(emails: List<Email>) = sortByPrimaryThenId(emails, isPrimary = { it.isPrimary }, dataId = { it.metadata?.dataId })
+    fun sortEmails(emails: List<Email>) =
+        sortByPrimaryThenId(dedupeEmails(emails), isPrimary = { it.isPrimary }, dataId = { it.metadata?.dataId })
+
+    // Aggregated contacts can expose the same number or email once per raw contact, sometimes
+    // with cosmetic differences. Collapse entries that share an identity (normalized value +
+    // label), keeping the first. See https://github.com/QuisApp/flutter_contacts/issues/229.
+    private fun dedupePhones(phones: List<Phone>): List<Phone> {
+        val seen = HashSet<Triple<String, String, String?>>()
+        return phones.filter { phone ->
+            val normalized = phone.normalizedNumber ?: return@filter true
+            seen.add(Triple(normalized, phone.label.label, phone.label.customLabel))
+        }
+    }
+
+    private fun dedupeEmails(emails: List<Email>): List<Email> {
+        val seen = HashSet<Triple<String, String, String?>>()
+        return emails.filter { email ->
+            val normalized = email.address.trim().lowercase().ifEmpty { return@filter true }
+            seen.add(Triple(normalized, email.label.label, email.label.customLabel))
+        }
+    }
 
     fun sortAddresses(addresses: List<Address>) = sortByDataId(addresses) { it.metadata?.dataId }
 

--- a/android/src/main/kotlin/co/quis/flutter_contacts/native/impl/ShowPickerImpl.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/native/impl/ShowPickerImpl.kt
@@ -4,8 +4,13 @@ import android.app.Activity
 import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.provider.ContactsContract
 import co.quis.flutter_contacts.common.BaseHandler
+import co.quis.flutter_contacts.common.argList
+import co.quis.flutter_contacts.crud.models.contact.Contact
+import co.quis.flutter_contacts.crud.utils.ContactFetcher
+import co.quis.flutter_contacts.listeners.utils.Permissions
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -17,6 +22,7 @@ class ShowPickerImpl(
 ) : BaseHandler(context, executor) {
     private var activityBinding: ActivityPluginBinding? = null
     private var pendingResult: MethodChannel.Result? = null
+    private var pendingProperties: Set<String> = emptySet()
     private var requestCode: Int = 0
 
     fun setActivityBinding(binding: ActivityPluginBinding?) {
@@ -41,6 +47,7 @@ class ShowPickerImpl(
         val activity =
             activityBinding?.activity ?: return postError(result, "No activity available")
         pendingResult = result
+        pendingProperties = call.argList<String>("properties")?.toSet() ?: emptySet()
         mainHandler.post {
             val intent =
                 Intent(Intent.ACTION_PICK).apply {
@@ -55,12 +62,40 @@ class ShowPickerImpl(
         data: Intent?,
     ) {
         val result = pendingResult ?: return
+        val properties = pendingProperties
         pendingResult = null
-        if (resultCode == Activity.RESULT_OK && data?.data != null) {
-            val contactId = ContentUris.parseId(data.data!!).toString()
-            postResult(result, contactId)
-        } else {
-            postResult(result, null)
+        pendingProperties = emptySet()
+        if (resultCode != Activity.RESULT_OK || data?.data == null) return postResult(result, null)
+        val pickedUri = data.data!!
+        val contactId = ContentUris.parseId(pickedUri).toString()
+        executor.execute {
+            // Empty properties: read displayName via the picker's temporary URI grant; no
+            // READ_CONTACTS needed. Non-empty properties: full projection requires READ_CONTACTS.
+            if (properties.isEmpty()) {
+                postResult(
+                    result,
+                    Contact(id = contactId, displayName = readDisplayName(pickedUri)).toJson(),
+                )
+                return@execute
+            }
+            if (!Permissions.hasReadPermission(context)) {
+                return@execute postError(
+                    result,
+                    "showPicker(properties: …) requires READ_CONTACTS on Android. " +
+                        "Grant the permission or call showPicker() without properties.",
+                )
+            }
+            val contact =
+                ContactFetcher.getContact(context.contentResolver, contactId, properties, null, null)
+                    ?: Contact(id = contactId)
+            postResult(result, contact.toJson())
         }
     }
+
+    private fun readDisplayName(uri: Uri): String? =
+        runCatching {
+            context.contentResolver
+                .query(uri, arrayOf(ContactsContract.Contacts.DISPLAY_NAME), null, null, null)
+                ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
+        }.getOrNull()
 }

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Flutter (1.0.0)
+  - flutter_contacts (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - flutter_contacts (from `.symlinks/plugins/flutter_contacts/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  flutter_contacts:
+    :path: ".symlinks/plugins/flutter_contacts/ios"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_contacts: 2ec1d6b62ca2869c3bbb3871bd74d4e3ef157135
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,11 +10,13 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		426CE0E571EA9830E6A8BDE5 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09B7127E8AF081F794FCB03A /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		EAA417C6665B0E1673D05A50 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70EA68E83E722BB2972881AD /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,11 +43,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		09B7127E8AF081F794FCB03A /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		15705F7FA7E99B0ED41CC6CF /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		283170FA2F056115CFA907B4 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		2E6007CB7E729083C624A934 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		348A7F1AA18F2919CDF1ACE6 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		70EA68E83E722BB2972881AD /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
@@ -57,14 +65,25 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B5DCBD83EC7494E3B8D5348A /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		F21B7BEEF359FA401E1B4C61 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3372A53A5D4ABE87C38C28B3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EAA417C6665B0E1673D05A50 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				426CE0E571EA9830E6A8BDE5 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -77,6 +96,15 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		90F284F33936153A1947E108 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				09B7127E8AF081F794FCB03A /* Pods_Runner.framework */,
+				70EA68E83E722BB2972881AD /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -98,6 +126,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				D82575226D827690B240658E /* Pods */,
+				90F284F33936153A1947E108 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -125,6 +155,20 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		D82575226D827690B240658E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F21B7BEEF359FA401E1B4C61 /* Pods-Runner.debug.xcconfig */,
+				348A7F1AA18F2919CDF1ACE6 /* Pods-Runner.release.xcconfig */,
+				283170FA2F056115CFA907B4 /* Pods-Runner.profile.xcconfig */,
+				15705F7FA7E99B0ED41CC6CF /* Pods-RunnerTests.debug.xcconfig */,
+				2E6007CB7E729083C624A934 /* Pods-RunnerTests.release.xcconfig */,
+				B5DCBD83EC7494E3B8D5348A /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -132,8 +176,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				FC2EA942FE2BA5888D3E2F33 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				3372A53A5D4ABE87C38C28B3 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -149,12 +195,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				29A383DCFE91E210372E9C02 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				BB2B097C9EDB6F164C6CC6B2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -232,6 +280,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		29A383DCFE91E210372E9C02 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -262,6 +332,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		BB2B097C9EDB6F164C6CC6B2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FC2EA942FE2BA5888D3E2F33 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -389,6 +498,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 15705F7FA7E99B0ED41CC6CF /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -406,6 +516,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2E6007CB7E729083C624A934 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -421,6 +532,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5DCBD83EC7494E3B8D5348A /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/example/macos/Flutter/Flutter-Debug.xcconfig
+++ b/example/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Flutter/Flutter-Release.xcconfig
+++ b/example/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,5 +8,5 @@ import Foundation
 import flutter_contacts
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-    FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
+  FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
 }

--- a/example/macos/Podfile
+++ b/example/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - flutter_contacts (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+
+DEPENDENCIES:
+  - flutter_contacts (from `Flutter/ephemeral/.symlinks/plugins/flutter_contacts/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+
+EXTERNAL SOURCES:
+  flutter_contacts:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_contacts/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+
+SPEC CHECKSUMS:
+  flutter_contacts: 6f45cdf49f4fb2241793263546f823f7e812668e
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -27,7 +27,9 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		5BCBE8C87C965339318CB418 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 302246BD50B04B24C62420C5 /* Pods_Runner.framework */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		BC1FCE68F6524D49511FF1C4 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFE0049C5EFAD6D0F993E1A0 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +63,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		236AA4E11C3ADB0522616D33 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		302246BD50B04B24C62420C5 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
@@ -77,9 +81,15 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		3846885592B3CED3C3262673 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		62931D6A6FE5DF44C79AF5CD /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		708F452B2855B0246E6D8A97 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9DBDEAF9629150D55937A7ED /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		E4C14D341D1516507A924973 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		EFE0049C5EFAD6D0F993E1A0 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC1FCE68F6524D49511FF1C4 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,12 +106,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				5BCBE8C87C965339318CB418 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E9B080A66FBE363424B088D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				302246BD50B04B24C62420C5 /* Pods_Runner.framework */,
+				EFE0049C5EFAD6D0F993E1A0 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		331C80D6294CF71000263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -127,6 +148,8 @@
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
+				4298E0999AE12DA06FAE62AD /* Pods */,
+				0E9B080A66FBE363424B088D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,6 +198,20 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		4298E0999AE12DA06FAE62AD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9DBDEAF9629150D55937A7ED /* Pods-Runner.debug.xcconfig */,
+				708F452B2855B0246E6D8A97 /* Pods-Runner.release.xcconfig */,
+				E4C14D341D1516507A924973 /* Pods-Runner.profile.xcconfig */,
+				3846885592B3CED3C3262673 /* Pods-RunnerTests.debug.xcconfig */,
+				236AA4E11C3ADB0522616D33 /* Pods-RunnerTests.release.xcconfig */,
+				62931D6A6FE5DF44C79AF5CD /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -182,6 +219,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				8022EABEFB6490F3B65D7711 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -200,11 +238,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				06107C40F7CCD84A383907A3 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				8D0643F9A1EDEF71A75AF280 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -293,6 +333,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		06107C40F7CCD84A383907A3 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -330,6 +392,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		8022EABEFB6490F3B65D7711 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8D0643F9A1EDEF71A75AF280 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -382,6 +483,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3846885592B3CED3C3262673 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -396,6 +498,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 236AA4E11C3ADB0522616D33 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -410,6 +513,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62931D6A6FE5DF44C79AF5CD /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/flutter_contacts/Sources/flutter_contacts/crud/utils/ContactConverter.swift
+++ b/ios/flutter_contacts/Sources/flutter_contacts/crud/utils/ContactConverter.swift
@@ -93,7 +93,9 @@ enum ContactConverter {
             json.setList("relations", cnContact.contactRelations.map { Relation(fromRelation: $0) }) { $0.toJson() }
         }
 
-        if options.wantsNotes, !cnContact.note.isEmpty {
+        // Note key isn't part of the picker's default fetch even with the entitlement;
+        // accessing an unfetched key raises an uncatchable NSException.
+        if options.wantsNotes, cnContact.isKeyAvailable(CNContactNoteKey), !cnContact.note.isEmpty {
             json.setList("notes", [Note(note: cnContact.note)]) { $0.toJson() }
         }
 

--- a/ios/flutter_contacts/Sources/flutter_contacts/native/impl/ShowPickerImpl.swift
+++ b/ios/flutter_contacts/Sources/flutter_contacts/native/impl/ShowPickerImpl.swift
@@ -6,9 +6,13 @@ import UIKit
 enum ShowPickerImpl {
     private static var pendingResult: FlutterResult?
     private static var pickerDelegate: PickerDelegate?
+    private static var requestedProperties: Set<String> = []
+    private static var enableIosNotes = false
 
-    static func handle(call _: FlutterMethodCall, result: @escaping FlutterResult) {
+    static func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
         pendingResult = result
+        requestedProperties = Set(call.argList("properties") as [String]? ?? [])
+        enableIosNotes = call.arg("enableIosNotes", default: false)
 
         DispatchQueue.main.async {
             guard let rootVC = ViewControllerUtils.rootViewController() else {
@@ -26,8 +30,10 @@ enum ShowPickerImpl {
         }
     }
 
-    static func completeWithResult(_ value: Any?) {
-        pendingResult?(value)
+    static func completeWithContact(_ contact: CNContact?) {
+        pendingResult?(contact.map {
+            ContactConverter.toJson($0, options: ContactConverter.makeOptions(properties: requestedProperties, enableIosNotes: enableIosNotes))
+        })
         pendingResult = nil
         pickerDelegate = nil
     }
@@ -36,13 +42,13 @@ enum ShowPickerImpl {
 private class PickerDelegate: NSObject, CNContactPickerDelegate {
     func contactPicker(_ picker: CNContactPickerViewController, didSelect contact: CNContact) {
         picker.dismiss(animated: true) {
-            ShowPickerImpl.completeWithResult(contact.identifier)
+            ShowPickerImpl.completeWithContact(contact)
         }
     }
 
     func contactPickerDidCancel(_ picker: CNContactPickerViewController) {
         picker.dismiss(animated: true) {
-            ShowPickerImpl.completeWithResult(nil)
+            ShowPickerImpl.completeWithContact(nil)
         }
     }
 }

--- a/lib/api/native_api.dart
+++ b/lib/api/native_api.dart
@@ -1,10 +1,17 @@
 import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import '../models/contact/contact.dart';
+import '../models/contact/contact_properties.dart';
+import '../models/contact/contact_property.dart';
+import '../models/contact/contact_property_extension.dart';
+import '../utils/json_helpers.dart';
+import 'config_api.dart';
 
-/// Native system UI API (Android & iOS only).
+/// Native system UI for picking, viewing, editing, and creating contacts
+/// (Android & iOS only).
 ///
-/// Provides access to native system dialogs for viewing, picking, editing, and creating contacts.
+/// Most calls avoid the contacts permission by handing off to the system UI.
+/// See each method for exceptions.
 class NativeApi {
   const NativeApi._();
 
@@ -25,27 +32,43 @@ class NativeApi {
     return _channel.invokeMethod<T>(method, args);
   }
 
-  /// Shows the native contact viewer dialog.
+  /// Shows the native contact viewer for [contactId].
+  ///
+  /// Permissionless on Android. On iOS requires `NSContactsUsageDescription`
+  /// in `Info.plist` and a granted read permission.
   Future<void> showViewer(String contactId) async {
     await _invoke<void>('native.showViewer', {'contactId': contactId});
   }
 
-  /// Shows the native contact picker dialog.
+  /// Shows the native contact picker dialog. Returns the picked contact, or
+  /// null if the user cancelled.
   ///
-  /// Returns the ID of the selected contact, or null if the user cancelled.
-  Future<String?> showPicker() => _invoke<String>('native.showPicker');
+  /// The picker itself is permissionless on both platforms. Calling without
+  /// [properties] always returns a [Contact] populated with `id` and
+  /// `displayName`.
+  ///
+  /// Passing non-empty [properties] asks for additional fields:
+  /// - iOS: always works.
+  /// - Android: requires `READ_CONTACTS`; throws a [PlatformException] otherwise.
+  Future<Contact?> showPicker({Set<ContactProperty>? properties}) async {
+    final result = await _invoke<Map>('native.showPicker', {
+      'properties': (properties ?? ContactProperties.none).toJson(),
+      if (Platform.isIOS) 'enableIosNotes': ConfigApi.instance.enableIosNotes,
+    });
+    return JsonHelpers.decode(result, Contact.fromJson);
+  }
 
-  /// Shows the native contact editor dialog.
+  /// Shows the native contact editor for [contactId]. Returns the saved
+  /// contact's ID, or null if the user cancelled.
   ///
-  /// Returns the ID of the contact if saved, or null if the user cancelled.
+  /// Same permissions as [showViewer].
   Future<String?> showEditor(String contactId) =>
       _invoke<String>('native.showEditor', {'contactId': contactId});
 
-  /// Shows the native contact creator dialog.
+  /// Shows the native contact creator, optionally pre-filled with [contact].
+  /// Returns the new contact's ID, or null if the user cancelled.
   ///
-  /// [contact] - Optional contact data to pre-fill the form.
-  ///
-  /// Returns the ID of the newly created contact if created, or null if the user cancelled.
+  /// Permissionless on both platforms.
   Future<String?> showCreator({Contact? contact}) => _invoke<String>(
     'native.showCreator',
     {if (contact != null) 'contact': contact.toJson()},

--- a/lib/flutter_contacts.dart
+++ b/lib/flutter_contacts.dart
@@ -129,7 +129,7 @@ export 'models/vcard/vcard_version.dart';
 /// // Native dialogs (Android & iOS only)
 /// class NativeApi {
 ///   Future<void> showViewer(String contactId);
-///   Future<String?> showPicker();
+///   Future<Contact?> showPicker({Set<ContactProperty>? properties});
 ///   Future<String?> showEditor(String contactId);
 ///   Future<String?> showCreator({Contact? contact});
 /// }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts
 description: "Fast, complete contact management for Android, iOS & macOS — all fields, groups, accounts, vCards, native dialogs, listeners, SIM contacts, and number blocking."
-version: 2.0.2
+version: 2.1.0
 repository: https://github.com/QuisApp/flutter_contacts
 
 environment:


### PR DESCRIPTION
## Summary
- Make `FlutterContacts.native.showPicker()` permissionless on both platforms; it now returns `Contact?` with `id` and `displayName` always populated, and accepts a `properties:` set for additional fields. On Android, requesting `properties` requires `READ_CONTACTS` and throws `PlatformException` otherwise (#232).
- Dedupe phone numbers and emails returned by aggregated contacts on Android, keyed on normalized value + label (#229).
- Bump to 2.1.0. **Breaking:** replace `await …showPicker()` with `(await …showPicker())?.id`.

## Test plan
- [x] Tested `showPicker()` (no properties) without `READ_CONTACTS` on Android → returns id + displayName
- [x] Tested `showPicker(properties: …)` without `READ_CONTACTS` on Android → throws `PlatformException`
- [x] Tested `showPicker()` and `showPicker(properties: …)` on iOS without `NSContactsUsageDescription` → both work
- [x] Tested existing example app on Pixel 6 and iPhone 14 → still builds and runs
- [x] Dart unit tests pass
- [x] Android lint / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)