### PR TITLE
Fix name update writing to wrong rawContactId with multiple raw contacts (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.1
+
+- Fix name updates writing to the wrong raw contact on Android contacts with
+  multiple raw contacts (e.g. Google + WhatsApp), by round-tripping the name's
+  `metadata` so its `rawContactId` is counted when picking the raw contact to
+  update (#236).
+
 ## 2.2.0
 
 - Round-trip unknown vCard properties via `contact.extras` (#21).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.2.1
 
 - Fix name updates writing to the wrong raw contact on Android contacts with
-  multiple raw contacts (e.g. Google + WhatsApp), by round-tripping the name's
-  `metadata` so its `rawContactId` is counted when picking the raw contact to
-  update (#236).
+  multiple raw contacts (e.g. Google + WhatsApp): the name is now updated in
+  place on the raw contact that already holds it, instead of the raw contact
+  with the most properties (#236).
 
 ## 2.2.0
 

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/models/properties/Name.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/models/properties/Name.kt
@@ -61,6 +61,7 @@ data class Name(
                         phoneticLast =
                             cursor.getStringOrNull(StructuredName.PHONETIC_FAMILY_NAME),
                         nickname = existingName?.nickname,
+                        metadata = PropertyHelpers.extractMetadata(cursor),
                     )
                 }
 

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/ContactBuilder.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/ContactBuilder.kt
@@ -125,7 +125,10 @@ object ContactBuilder {
                 // Limits: a name living only on a read-only raw contact can't be edited, and
                 // clearing a name may let another raw contact's name resurface.
                 val nameRawContactId =
-                    existingContact.name?.metadata?.rawContactId?.toLongOrNull() ?: rawContactId
+                    existingContact.name
+                        ?.metadata
+                        ?.rawContactId
+                        ?.toLongOrNull() ?: rawContactId
                 ops.addAll(it.toUpdateOperations(nameRawContactId))
             }
         }

--- a/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/ContactBuilder.kt
+++ b/android/src/main/kotlin/co/quis/flutter_contacts/crud/utils/ContactBuilder.kt
@@ -117,7 +117,18 @@ object ContactBuilder {
             if (property in properties) block()
         }
 
-        updateIf("name") { newContact.name?.let { ops.addAll(it.toUpdateOperations(rawContactId)) } }
+        updateIf("name") {
+            newContact.name?.let {
+                // Update the name in place on the raw contact that already holds it, falling back
+                // to the primary when the contact has no name yet. Otherwise multi-account
+                // contacts (e.g. Google + WhatsApp) can route it to the wrong raw contact (#236).
+                // Limits: a name living only on a read-only raw contact can't be edited, and
+                // clearing a name may let another raw contact's name resurface.
+                val nameRawContactId =
+                    existingContact.name?.metadata?.rawContactId?.toLongOrNull() ?: rawContactId
+                ops.addAll(it.toUpdateOperations(nameRawContactId))
+            }
+        }
         updateIf("phone") {
             PropertyListUpdater.updatePhones(ops, existingContact.phones, newContact.phones, rawContactId)
         }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/models/properties/name.dart
+++ b/lib/models/properties/name.dart
@@ -1,4 +1,5 @@
 import '../../utils/json_helpers.dart';
+import 'property_metadata.dart';
 
 /// Structured name property.
 ///
@@ -51,6 +52,9 @@ class Name {
   /// Nickname.
   final String? nickname;
 
+  /// Property identity metadata (used internally for updates).
+  final PropertyMetadata? metadata;
+
   const Name({
     this.first,
     this.middle,
@@ -62,6 +66,7 @@ class Name {
     this.phoneticLast,
     this.previousFamilyName,
     this.nickname,
+    this.metadata,
   });
 
   Map<String, dynamic> toJson() {
@@ -76,6 +81,7 @@ class Name {
     JsonHelpers.encode(json, 'phoneticLast', phoneticLast);
     JsonHelpers.encode(json, 'previousFamilyName', previousFamilyName);
     JsonHelpers.encode(json, 'nickname', nickname);
+    JsonHelpers.encode(json, 'metadata', metadata, (m) => m.toJson());
     return json;
   }
 
@@ -93,6 +99,7 @@ class Name {
         json['previousFamilyName'],
       ),
       nickname: JsonHelpers.decode<String>(json['nickname']),
+      metadata: JsonHelpers.decode(json['metadata'], PropertyMetadata.fromJson),
     );
   }
 
@@ -139,6 +146,7 @@ class Name {
     String? phoneticLast,
     String? previousFamilyName,
     String? nickname,
+    PropertyMetadata? metadata,
   }) => Name(
     first: first ?? this.first,
     middle: middle ?? this.middle,
@@ -150,5 +158,6 @@ class Name {
     phoneticLast: phoneticLast ?? this.phoneticLast,
     previousFamilyName: previousFamilyName ?? this.previousFamilyName,
     nickname: nickname ?? this.nickname,
+    metadata: metadata ?? this.metadata,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts
 description: "Fast, complete contact management for Android, iOS & macOS — all fields, groups, accounts, vCards, native dialogs, listeners, SIM contacts, and number blocking."
-version: 2.2.0
+version: 2.2.1
 repository: https://github.com/QuisApp/flutter_contacts
 
 environment:


### PR DESCRIPTION
Fixes #236.

## Problem

On Android contacts with multiple raw contacts (e.g. a Google account + WhatsApp), updating the name silently failed — `update()` returned successfully but the name was unchanged on re-fetch.

On update, the plugin picks a single "primary" raw contact (the one with the most existing properties) and writes the `StructuredName` there. The structured name has **no `dataId` matching** — it's a delete-all-then-reinsert keyed on the raw contact. So when the heuristic picked the *wrong* raw contact (often the WhatsApp one), the name was deleted/inserted on a raw contact that didn't hold it, while the raw contact that actually sources the displayed name (the Google one) was left untouched → silent no-op.

(The structured first/middle/last in the reporter's logcat confirms the name lived on the writable Google raw contact, not WhatsApp — so the root cause is wrong-target routing, not WhatsApp being read-only.)

## Fix

Route the name write to the raw contact that **already holds the name**, instead of the property-count "primary":

- **`Name.fromCursor` (Kotlin)** — extract `metadata` (via `PropertyHelpers.extractMetadata`) so `existingContact.name` carries its `rawContactId`, the same as every other property already does. This is the load-bearing change.
- **`ContactBuilder.buildUpdateOperations`** — write the name to `existingContact.name.metadata.rawContactId`, falling back to the primary only when the contact has no name yet (the add case).
- **Dart `Name`** — add the `metadata` field for parity with `Phone`/`Email`/etc. (Not required for the fix — the routing is computed server-side from `existingContact` — but keeps `Name` consistent and captures the metadata Kotlin now sends.)

List properties are unaffected: they match by `dataId` and update in place regardless of the primary.

### Known limits (documented in code)
- A name living only on a read-only raw contact (e.g. a WhatsApp-only contact) still can't be edited — inherent platform limitation.
- Clearing a name may let a lower-priority raw contact's name resurface. (A future enhancement could best-effort-clear the name on the other raw contacts; it needs non-atomic batches and is out of scope here.)

## Testing

- `./scripts/test.sh` — Dart 49/49, Kotlin `BUILD SUCCESSFUL`, Swift iOS + macOS pass.
- `dart analyze` clean; `./scripts/format.sh` applied.
- Plugin Kotlin compiles (`compileDebugKotlin`).
- ⚠️ Not yet confirmed on a physical Google+WhatsApp device — the logic is verified by inspection but a hardware repro of #236 would be the conclusive check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)